### PR TITLE
Adds winbar support and more configuration options

### DIFF
--- a/lua/plainline/core.lua
+++ b/lua/plainline/core.lua
@@ -124,6 +124,14 @@ end
 local function setup_globals(config)
   vim.go.statusline = "%{%v:lua.require'plainline.core'.on()%}"
 
+  -- Tragically, quickfix tries to set its own statusline.
+  -- See: https://github.com/neovim/neovim/issues/27731
+  vim.api.nvim_create_autocmd({'FileType'}, {
+    pattern = 'qf',
+    command = 'setl statusline=',
+    group=this.plainline_group,
+  })
+
   if config.winbar then
     -- Unfortunately, this still needs to be run using autocommands
     vim.api.nvim_create_autocmd({ "WinEnter", "BufEnter" }, {
@@ -156,7 +164,7 @@ function this.enable(config)
 
   -- If laststatus is set to 3, this means the user has a global status bar,
   -- which means there is no need to set it individually for each window.
-  if vim.o.laststatus == 3 then
+  if vim.go.laststatus == 3 then
     setup_globals(config)
   else
     setup_locals(config)

--- a/lua/plainline/core.lua
+++ b/lua/plainline/core.lua
@@ -33,7 +33,8 @@ local function get_ptable(sections)
 end
 
 -- Takes a table of functions (as produced by get_ptable), calls them and
--- formats their results into a string, using the separator
+-- formats each result using the `formatter` from the config and then joins
+-- the formatted results into the final string, using the `separator`.
 local function mkstatus(ptable, config)
   local separator = config.separator
   local formatter = config.formatter
@@ -153,10 +154,12 @@ function this.enable(config)
     this.winbar_off = function() return mkstatus(winbar_off, config) end
   end
 
-  if not config.global then
-    setup_locals(config)
-  else
+  -- If laststatus is set to 3, this means the user has a global status bar,
+  -- which means there is no need to set it individually for each window.
+  if vim.o.laststatus == 3 then
     setup_globals(config)
+  else
+    setup_locals(config)
   end
 
   -- Set up ocasional updates to the b:plainline_branch variable

--- a/lua/plainline/init.lua
+++ b/lua/plainline/init.lua
@@ -24,6 +24,10 @@ local function full_config(user_config)
       if not preset then
          error(string.format("Inexistent plainline preset: %s", user_config))
       end
+      if preset ~= presets.default then
+        -- Makes all presets fallback to the default configuration
+        setmetatable(preset, {__index=preset})
+      end
       return preset
    end
    user_config = user_config or {}

--- a/lua/plainline/init.lua
+++ b/lua/plainline/init.lua
@@ -24,10 +24,6 @@ local function full_config(user_config)
       if not preset then
          error(string.format("Inexistent plainline preset: %s", user_config))
       end
-      if preset ~= presets.default then
-        -- Makes all presets fallback to the default configuration
-        setmetatable(preset, {__index=preset})
-      end
       return preset
    end
    user_config = user_config or {}

--- a/lua/plainline/init.lua
+++ b/lua/plainline/init.lua
@@ -24,7 +24,7 @@ local function full_config(user_config)
       if not preset then
          error(string.format("Inexistent plainline preset: %s", user_config))
       end
-      return preset
+      user_config = preset
    end
    user_config = user_config or {}
    local config = vim.tbl_deep_extend("keep", user_config, presets.default)

--- a/lua/plainline/presets.lua
+++ b/lua/plainline/presets.lua
@@ -39,7 +39,10 @@ return {
       left  = { "path" },
       right = { "percentage" },
     },
-    separator = " │ ",
+    global = false,
+    separator = "│",
+    formatter = function (component) return string.format(' %s ', component) end,
+    winbar = nil,
   },
   -- Emulation of the stock emacs modeline
   emacs = {


### PR DESCRIPTION
This PR adds winbar support as a new section in `setup`. To keep backwards compatibility with the default preset, it is disabled by default.

To enable winbar, you need to define a `winbar` table in `setup`. This table currently only accepts `sections` and `inactive_sections` tables, configured the same as the normal `plainline`.

~There is also a new `global` option, which when set to `true`,~ When `laststatus` is set to `3`, sets the status line globally instead of using autocommands. This also has the effect of only setting the `section` for both the statusline and winbar.

There is also a new `formatter` function that gets run for every provider, which allows for greater customization. It simply receives earch provider's output and returns a new string. To keep backwards compatibility with the default preset, it adds spaces around the output.

The `separator` option was adjusted accordingly.

Now, every preset implicitly "inherits" options from the `default` preset. This is to simplify configuration and define default values for all options.
